### PR TITLE
Add Dynamic DNS Lookup

### DIFF
--- a/wwwroot/cgi-bin/awstats.model.conf
+++ b/wwwroot/cgi-bin/awstats.model.conf
@@ -191,6 +191,19 @@ HostAliases="localhost 127.0.0.1 REGEX[myserver\.com$]"
 DNSLookup=2
 
 
+# For very large sites, setting DNSLookup to 0 (or 2) might be the only
+# reasonable choice. DynamicDNSLookup allows to resolve host names for
+# items shown in html tables only.
+# Possible values:
+# 0 - No dynamic DNS lookup 
+# 1 - Dynamic DNS lookup enabled
+# 2 - Dynamic DNS lookup enabled (including static DNS cache file as a second
+#     source)
+# Default: 0
+#
+DynamicDNSLookup=0
+
+
 # When AWStats updates its statistics, it stores results of its analysis in 
 # files (AWStats database). All those files are written in the directory
 # defined by the "DirData" parameter. Set this value to the directory where

--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -182,7 +182,7 @@ $BuildHistoryFormat    = 'text';
 $ExtraTrackedRowsLimit = 500;
 $DatabaseBreak         = 'month';
 use vars qw/
-  $DebugMessages $AllowToUpdateStatsFromBrowser $EnableLockForUpdate $DNSLookup $AllowAccessFromWebToAuthenticatedUsersOnly
+  $DebugMessages $AllowToUpdateStatsFromBrowser $EnableLockForUpdate $DNSLookup $DynamicDNSLookup $AllowAccessFromWebToAuthenticatedUsersOnly
   $BarHeight $BarWidth $CreateDirDataIfNotExists $KeepBackupOfHistoricFiles
   $NbOfLinesParsed $NbOfLinesDropped $NbOfLinesCorrupted $NbOfLinesComment $NbOfLinesBlank $NbOfOldLines $NbOfNewLines
   $NbOfLinesShowsteps $NewLinePhase $NbOfLinesForCorruptedLog $PurgeLogFile $ArchiveLogRecords
@@ -199,6 +199,7 @@ use vars qw/
 	$AllowToUpdateStatsFromBrowser,
 	$EnableLockForUpdate,
 	$DNSLookup,
+	$DynamicDNSLookup,
 	$AllowAccessFromWebToAuthenticatedUsersOnly,
 	$BarHeight,
 	$BarWidth,
@@ -241,7 +242,7 @@ use vars qw/
 	$DecodePunycode
   )
   = (
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
   );
 use vars qw/
@@ -12534,11 +12535,37 @@ sub HTMLShowHosts{
 		&BuildKeyList( $MaxRowsInHTMLOutput, $MinHit{'Host'}, \%_host_h,
 			\%_host_l );
 	}
+	my $regipv4=qr/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
+
+	if ( $DynamicDNSLookup == 2 ) {
+		# Use static DNS file
+		&Read_DNS_Cache( \%MyDNSTable, "$DNSStaticCacheFile", "", 1 );
+	}
+
 	foreach my $key (@keylist) {
 		my $host = CleanXSS($key);
 		print "<tr><td class=\"aws\">"
 		  . ( $_robot_l{$key} ? '<b>'  : '' ) . "$host"
-		  . ( $_robot_l{$key} ? '</b>' : '' ) . "</td>";
+		  . ( $_robot_l{$key} ? '</b>' : '' );
+
+		if ($DynamicDNSLookup) {
+			# Dynamic reverse DNS lookup
+        	        if ($host =~ /$regipv4/o) {
+                	        my $lookupresult=lc(gethostbyaddr(pack("C4",split(/\./,$host)),AF_INET));       # This may be slow
+                        	if (! $lookupresult || $lookupresult =~ /$regipv4/o || ! IsAscii($lookupresult)) {
+					if ( $DynamicDNSLookup == 2 ) {
+						# Check static DNS file
+						$lookupresult = $MyDNSTable{$host};
+						if ($lookupresult) { print " ($lookupresult)"; }
+						else { print ""; }
+					}
+					else { print ""; }
+	                        }
+        	                else { print " ($lookupresult)"; }
+	                }
+		}
+
+		print "</td>";
 		&HTMLShowHostInfo($key);
 		if ( $ShowHostsStats =~ /P/i ) {
 			print "<td>"
@@ -14912,9 +14939,35 @@ sub HTMLMainHosts{
 	my $total_p = my $total_h = my $total_k = 0;
 	my $count = 0;
 	
+	my $regipv4 = qr/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;	
+
+        if ( $DynamicDNSLookup == 2 ) {
+	        # Use static DNS file
+                &Read_DNS_Cache( \%MyDNSTable, "$DNSStaticCacheFile", "", 1 );
+        }
+
 	foreach my $key (@keylist) {
 		print "<tr>";
-		print "<td class=\"aws\">$key</td>";
+		print "<td class=\"aws\">$key";
+
+		if ($DynamicDNSLookup) {
+	                # Dynamic reverse DNS lookup
+	                if ($key =~ /$regipv4/o) {
+		                my $lookupresult=lc(gethostbyaddr(pack("C4",split(/\./,$key)),AF_INET));	# This may be slow
+                	        if (! $lookupresult || $lookupresult =~ /$regipv4/o || ! IsAscii($lookupresult)) {
+                                        if ( $DynamicDNSLookup == 2 ) {
+                                                # Check static DNS file
+                                                $lookupresult = $MyDNSTable{$key};
+                                                if ($lookupresult) { print " ($lookupresult)"; }
+                                                else { print ""; }
+                                        }
+                                        else { print ""; }
+                                }
+                                else { print " ($lookupresult)"; }
+                        }
+                }
+
+		print "</td>";
 		&HTMLShowHostInfo($key);
 		if ( $ShowHostsStats =~ /P/i ) {
 			print '<td>' . ( Format_Number($_host_p{$key}) || "&nbsp;" ) . '</td>';


### PR DESCRIPTION
For very large sites, setting DNSLookup to 0 might be the only reasonable choice. DynamicDNSLookup allows to resolve host names for items shown in html tables only.

Our experience from processing a quite large site (http://meteo.pl) with 8-10 millions hits a day is positive. Typical "dynamic resolving" overhead never has exceeded few seconds.
