### PR TITLE
NEW Cut port from server name to keep only ip

### DIFF
--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -19200,6 +19200,11 @@ if ( $UpdateStats && $FrameName ne 'index' && $FrameName ne 'mainleft' )
 		my $HostResolved = ''
 		  ; # HostResolved will be defined in next paragraf if countedtraffic is true
 
+		if( $Host =~ /^([^:]+):[0-9]+$/ ){ # Host may sometimes have an ip:port syntax (ex: 54.32.12.12:60321)
+		    $Host = $1;
+		}
+
+
 		if ( !$countedtraffic || $countedtraffic == 6) {
 			my $ip = 0;
 			if ($DNSLookup) {    # DNS lookup is 1 or 2


### PR DESCRIPTION
I have log (from AWS load balancer) that have an ip syntaxe with port (ex: 54.32.12.1:60321)

The change is only to cut the port and only keep the ip, so the geoip tools could work correctly then.

I'm not a perl expert, but it work on my installation with my data.
