### PR TITLE
Add partial support for pure-ftpd stats format in method field

### DIFF
--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -18343,6 +18343,7 @@ if ( $UpdateStats && $FrameName ne 'index' && $FrameName ne 'mainleft' )
 		elsif (
 			$LogType eq 'F'
 			&& (   $field[$pos_method] eq 'RETR'
+				|| $field[$pos_method] eq 'D'
 				|| $field[$pos_method] eq 'o'
 				|| $field[$pos_method] =~ /$regget/o )
 		  )
@@ -18353,6 +18354,7 @@ if ( $UpdateStats && $FrameName ne 'index' && $FrameName ne 'mainleft' )
 		elsif (
 			$LogType eq 'F'
 			&& (   $field[$pos_method] eq 'STOR'
+				|| $field[$pos_method] eq 'U'
 				|| $field[$pos_method] eq 'i'
 				|| $field[$pos_method] =~ /$regsent/o )
 		  )


### PR DESCRIPTION
pure-ftpd provides an alternative 'stats' log format, which is defined here:
https://github.com/jedisct1/pure-ftpd/blob/master/src/altlog.c#L60

Such a logline look like this:

```
1470402631 57a49043.26d1 user.name 192.168.21.53 D 3085021 4 /data/ftp/path/to/file.zip
```

awstats on one side insists on having a code and method in LogFormat, for code i can cheat and use the second field (which is more or less a session id - i'd rather have awstats avoid enforcing code for LogType=F..) but for method, i need to add support for D/U values to avoid awstats dropping the record.

With this PR, and the following LogFormat:

```
LogFormat="%time4 %code %logname %host %method %bytesd %extra1 %url"
```

awstats successfully parses the log. %extra1 is the time it took for the download.
