### PR TITLE
Fix browser detection with HTTP 206 status code

### DIFF
--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -19026,7 +19026,7 @@ if ( $UpdateStats && $FrameName ne 'index' && $FrameName ne 'mainleft' )
 
 		# Analyze: Robot from robot database (=> countedtraffic=4 if robot)
 		#------------------------------------------------------------------
-		if ( !$countedtraffic ) {
+		if ( !$countedtraffic || $countedtraffic == 6) {
 			if ( $pos_agent >= 0 ) {
 				if ($DecodeUA) {
 					$field[$pos_agent] =~ s/%20/_/g;


### PR DESCRIPTION
There is a problem with browser detection on log lines that have the 206 status code. `$UserAgent` variable is not reset and remains either uninitialized or contains the old value from the previous request. 

This causes some unusual behavior. For instance, bot user agents that should have been caught by entries in `robots.pm` appear in "Unknown browsers" list.

The following `access.log` can be used to reproduce this bug ("Googlebot" appears both under the "Robots" and "Unknown browsers" lists):

```
1.1.1.1 - - [16/Mar/2017:11:59:41 +0100] "GET /index.html HTTP/1.1" 200 1 1 + "-" "Googlebot/2.1" www.example.com 80
2.2.2.2 - - [16/Mar/2017:11:59:44 +0100] "GET /index.pdf HTTP/1.1" 206 1 1 + "-" "Firefox/52.0" www.example.com 80
```

The pull request fixes this by making the `$UserAgent` setting code also run for requests with the 206 status code.