### PR TITLE
Fix "Illegal division by zero" error.

### DIFF
--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -14306,7 +14306,7 @@ sub HTMLMainDownloads{
 		if ($cnt > 4){last;}
 	}
 	# Graph the top five in a pie chart
-	if (scalar keys %_downloads > 1){
+	if (($Totalh > 0) and (scalar keys %_downloads > 1)){
 		foreach my $pluginname ( keys %{ $PluginsLoaded{'ShowGraph'} } )
 		{
 			my @blocklabel = ();


### PR DESCRIPTION
This is a proposed fix for issue #15. 

`$Totalh` (total hits) is zero when you have downloads with only 206 hits. This commit adds a check for this case to the `if` around the pie chart code (the chart is skipped in this case).