### PR TITLE
Format Tera Bytes

### DIFF
--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -8104,6 +8104,9 @@ sub Format_Bytes {
 	my $fudge = 1;
 
 # Do not use exp/log function to calculate 1024power, function make segfault on some unix/perl versions
+	if ( $bytes >= ( $fudge << 40 ) ) {
+		return sprintf( "%.2f", $bytes / 1099511627776 ) . " $Message[179]";
+	}
 	if ( $bytes >= ( $fudge << 30 ) ) {
 		return sprintf( "%.2f", $bytes / 1073741824 ) . " $Message[110]";
 	}

--- a/wwwroot/cgi-bin/lang/awstats-en.txt
+++ b/wwwroot/cgi-bin/lang/awstats-en.txt
@@ -180,3 +180,4 @@ message175=Chrome versions
 message176=Konqueror versions
 message177=,
 message178=Downloads
+message179=TB


### PR DESCRIPTION
Last month my server pushed several Tera Bytes (TB) of data and I noticed that AWStats isn't formatting this well, so I'm suggesting this small modification TB format.