### PR TITLE
Decode RFC 3986 "unreserved chars" in URLs.

### DIFF
--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -7907,6 +7907,22 @@ sub DecodeEncodedString {
 }
 
 #------------------------------------------------------------------------------
+# Function:     Similar to DecodeEncodedString, but decode only
+#               RFC3986 "unreserved characters"
+# Parameters:   stringtodecode
+# Input:        None
+# Output:       None
+# Return:       decodedstring
+#------------------------------------------------------------------------------
+sub DecodeRFC3986UnreservedString {
+	my $stringtodecode = shift;
+
+	$stringtodecode =~ s/%([46][1-9A-F]|[57][0-9A]|3[0-9]|2D|2E|5F|7E)/pack("C", hex($1))/ieg;
+
+	return $stringtodecode;
+}
+
+#------------------------------------------------------------------------------
 # Function:     Decode a precompiled regex value to a common regex value
 # Parameters:   compiledregextodecode
 # Input:        None
@@ -18718,6 +18734,14 @@ if ( $UpdateStats && $FrameName ne 'index' && $FrameName ne 'mainleft' )
 	# We keep a clean $field[$pos_url] and
 	# we store original value for urlwithnoquery, tokenquery and standalonequery
 	#---------------------------------------------------------------------------
+
+		# Decode "unreserved characters" - URIs with common ASCII characters
+		# percent-encoded are equivalent to their unencoded versions.
+		#
+		# See section 2.3. of RFC 3986.
+
+		$field[$pos_url] = DecodeRFC3986UnreservedString($field[$pos_url]);
+
 		if ($URLNotCaseSensitive) { $field[$pos_url] = lc( $field[$pos_url] ); }
 
 # Possible URL syntax for $field[$pos_url]: /mydir/mypage.ext?param1=x&param2=y#aaa, /mydir/mypage.ext#aaa, /


### PR DESCRIPTION
awstats 7.7 treats `/foo` and `/%66%6f%6f` as two different URIs. [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), section 2.3. states that URIs that have some common ASCII characters replaced with their percent-encoded equivalents, should be treated as identical. Apache for example, will serve the same resource in such case. In practice, this mostly seems to affect URIs that include the tilde (`~`) character. It appears that a lot of user agents in the wild will percent-encode it, even though it is not strictly necessary.

This pull request makes awstats percent-decode the "unreserved" character range early in the process. This way, requests for "/foo" and "/%66%6f%6f" appear as one row in the "Pages-URL"  statistics.

Note that this change only affects some common characters from the ASCII range (ALPHA / DIGIT / "-" / "." / "_" / "~"). It doesn't do any kind of UTF-8 decoding (as discussed [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=655528), for example)