### PR TITLE
Ignore search phrases longer than 80 characters.

### DIFF
--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -19986,7 +19986,7 @@ s/^(cache|related):[^\+]+//
 													$param =~ s/^ +//;
 													$param =~ s/ +$//;    # Trim
 													$param =~ tr/ /\+/s;
-													if ( ( length $param ) > 0 )
+													if ( ( ( length $param ) > 0 ) and ( ( length $param ) < 80 ) )
 													{
 														$_keyphrases{$param}++;
 													}


### PR DESCRIPTION
Sometimes very long URLs get parsed as search phrases. This leads to an unreadable search phrase table in awstats. This pull request attempts to fix this by ignoring extracted search phrases that are longer than 80 characters.

![awstats](https://user-images.githubusercontent.com/1135442/42494849-b1b3baaa-8421-11e8-9394-5e50cdc12dd1.png)
