### PR TITLE
Improving error handling in awstats_buildstaticpages.pl

### DIFF
--- a/tools/awstats_buildstaticpages.pl
+++ b/tools/awstats_buildstaticpages.pl
@@ -380,6 +380,7 @@ if ($Update) {
 	$command .= " -databasebreak=$DatabaseBreak" if defined $DatabaseBreak;
 	print "Launch update process : $command\n";
 	$retour=`$command  2>&1`;
+    if ($?) { print $retour; exit $?; }
 }
 
 # Built the OutputSuffix value (used later to build page name)
@@ -437,6 +438,7 @@ if ($DatabaseBreak) { $smallcommand.=" -databasebreak=$DatabaseBreak"; }
 my $command="$smallcommand -output";
 print "Build main page: $command\n";
 $retour=`$command  2>&1`;
+if ($?) { print $retour; exit $?; }
 $OutputFile=($OutputDir?$OutputDir:"")."awstats.$OutputSuffix.$StaticExt";
 open("OUTPUT",">$OutputFile") || error("Couldn't open log file \"$OutputFile\" for writing : $!");
 print OUTPUT $retour;
@@ -449,6 +451,7 @@ for my $output (@OutputList) {
 	my $command="$smallcommand -output=$output";
 	print "Build $output page: $command\n";
 	$retour=`$command  2>&1`;
+    if ($?) { print $retour; exit $?; }
 	$OutputFile=($OutputDir?$OutputDir:"")."awstats.$OutputSuffix.$output.$StaticExt";
 	open("OUTPUT",">$OutputFile") || error("Couldn't open log file \"$OutputFile\" for writing : $!");
 	print OUTPUT $retour;
@@ -464,6 +467,7 @@ if ($QueryString =~ /(^|-|&)buildpdf/i) {
 	my $command="\"$HtmlDoc\" -t pdf --webpage --quiet --no-title --textfont helvetica --left 16 --bottom 8 --top 8 --browserwidth 800 --headfootsize 8.0 --fontsize 7.0 --header xtx --footer xd/ --outfile $OutputFile @pages\n";
 	print "Build PDF file : $command\n";
 	$retour=`$command  2>&1`;
+    if ($?) { print $retour; exit $?; }
     my $signal_num=$? & 127;
 	my $dumped_core=$? & 128;
 	my $exit_value=$? >> 8;


### PR DESCRIPTION
Thanks to this I was able to catch this error:
```
$ /usr/share/awstats/tools/awstats_buildstaticpages.pl -config=local -update -dir=/usr/share/nginx/html/awstats
...
Create/Update database for config "/etc/awstats/awstats.conf" by AWStats version 7.2 (build 1.992)
From data in log file "/usr/share/awstats/tools/logresolvemerge.pl /var/log/nginx/access.log /var/log/nginx/access.log.1"...
Error: Couldn't open server log file "/usr/share/awstats/tools/logresolvemerge.pl /var/log/nginx/access.log /var/log/nginx/access.log.1" : No such file or directory
Setup ('/etc/awstats/awstats.conf' file, web server or permissions) may be wrong.
Check config file, permissions and AWStats documentation (in 'docs' directory).
```