### PR TITLE
Add a few more protections if current name doesn't resolve anymore.

### DIFF
--- a/wwwroot/cgi-bin/plugins/geoip2.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2.pm
@@ -196,16 +196,22 @@ sub ShowInfoHost_geoip2 {
 		if (! $key) {
         	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param key=$key ip=$ip",5); }
 			my $res = TmpLookup_geoip2($param);
+            if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param res=$res",5);}
             # First resolve the name to an IP
-            $address = inet_ntoa(inet_aton($param));
-            if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 $param resolved to $address",5); }
-            # Now do the same lookup from the IP
-            # GeoIP2::Reader doesn't support private IP addresses
-            if (!is_private_ip($address)){
-        	if (!$res){$res=lc($reader->country( ip => $address )->country()->iso_code()) if $reader;}
-        	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param: [$res]",5); }
-		    if ($res) { print $DomainsHashIDLib{$res}?$DomainsHashIDLib{$res}:"<span style=\"color: #$color_other\">$Message[0]</span>"; }
-		    else { print "<span style=\"color: #$color_other\">$Message[0]</span>"; }
+            $inet_n = inet_aton($param);
+            if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param inet_n=$inet_n",5);}
+            # Check to see if we resolved the name to number - if not bail
+            if ($inet_n) {
+                $address = inet_ntoa($inet_n);
+                if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 $param resolved to $address",5); }
+                # Now do the same lookup from the IP
+                # GeoIP2::Reader doesn't support private IP addresses
+                if (!is_private_ip($address)){
+                if (!$res){$res=lc($reader->country( ip => $address )->country()->iso_code()) if $reader;}
+                if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param: [$res]",5); }
+                if ($res) { print $DomainsHashIDLib{$res}?$DomainsHashIDLib{$res}:"<span style=\"color: #$color_other\">$Message[0]</span>"; }
+                else { print "<span style=\"color: #$color_other\">$Message[0]</span>"; }
+            }
 		}}
 		print "</td>";
 	}

--- a/wwwroot/cgi-bin/plugins/geoip2.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2.pm
@@ -118,7 +118,7 @@ sub GetCountryCodeByName_geoip2 {
     my $param="$_[0]";
 	# <-----
 	if (! $param) { return ''; }
-	my $res = TmpLookup_geoip($param);
+	my $res = TmpLookup_geoip2($param);
 	if (! $res) {
         # First resolve the name to an IP
         $address = inet_ntoa(inet_aton($param));

--- a/wwwroot/cgi-bin/plugins/geoip2_city.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2_city.pm
@@ -303,15 +303,20 @@ sub ShowInfoHost_geoip2_city {
 			{
 	        	my $record=();
                 # First resolve the name to an IP
-                $address = inet_ntoa(inet_aton($param));
-                if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2_city $param resolved to $address",5); }
-                # Now do the same lookup from the IP
-                # GeoIP2::Reader doesn't support lookups for Private IPs
-                if (!is_private_ip($address)){
-	        	$record=$geoip2_city->city(ip=>$address) if $geoip2_city;
-	        	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2_city for $param: [$record]",5); }
-	            $country=$record->country()->iso_code() if $record;
-	            $city=$record->city()->name() if $record;
+                $inet_n = inet_aton($param);
+                if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2_city for $param inet_n=$inet_n",5);}
+                # Check to see if we resolved the name to number - if not bail
+                if ($inet_n) {
+                    $address = inet_ntoa($inet_n);
+                    if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2_city $param resolved to $address",5); }
+                    # Now do the same lookup from the IP
+                    # GeoIP2::Reader doesn't support lookups for Private IPs
+                    if (!is_private_ip($address)){
+                    $record=$geoip2_city->city(ip=>$address) if $geoip2_city;
+                    if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2_city for $param: [$record]",5); }
+                    $country=$record->country()->iso_code() if $record;
+                    $city=$record->city()->name() if $record;
+                }
 			}}
 #			print "<td>";
 #		    if ($country) { print $DomainsHashIDLib{$country}?$DomainsHashIDLib{$country}:"<span style=\"color: #$color_other\">$Message[0]</span>"; }


### PR DESCRIPTION
Looking at previous reports, if a name was no longer resolving either because the DNS entry was no longer there, or a temporary failure in DNS resolution, the current code would fail at the `$address = inet_ntoa(inet_aton($param));` line. Added some logic that if the `inet_aton` returned nothing, then skip this entry and keep going.