### PR TITLE
Supprime les erreurs du paquet geoip2 de Maxmind

### DIFF
--- a/wwwroot/cgi-bin/plugins/geoip2.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2.pm
@@ -52,7 +52,6 @@ my %TmpDomainLookup;
 use vars qw/
 $reader
 /;
-use Data::Validate::IP 0.25 qw( is_private_ip );
 # ----->
 
 
@@ -96,14 +95,22 @@ sub GetCountryCodeByAddr_geoip2 {
     my $param="$_[0]";
 	# <-----
 	if (! $param) { return ''; }
-	my $res= TmpLookup_geoip2($param);
-	if (! $res) {
+	# APM debut ligne d'origine apres eval { et avant 1; , le my devant $res doit etre hors bloc
+	my $res='unknown';
+	eval {
+	#$res= TmpLookup_geoip2($param);
+	#if (! $res) {
 		if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param",5); }
 		$res=lc($reader->country( ip => $param )->country()->iso_code()) || 'unknown';
 		$TmpDomainLookup{$param}=$res;
 		if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param: [$res]",5); }
-	}
-	elsif ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param: Already resolved to [$res]",5); }
+	#}
+	#elsif ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param: Already resolved to [$res]",5); }
+		1;
+	} or do {
+		$res='unknown';
+	};
+	# APM fin
 	# ----->
 	return $res;
 }
@@ -118,7 +125,10 @@ sub GetCountryCodeByName_geoip2 {
     my $param="$_[0]";
 	# <-----
 	if (! $param) { return ''; }
-	my $res = TmpLookup_geoip($param);
+	# APM debut ligne d'origine apres eval { et avant 1;
+	my $res='unknown';
+	eval {
+	$res = TmpLookup_geoip($param);
 	if (! $res) {
         # First resolve the name to an IP
         $address = inet_ntoa(inet_aton($param));
@@ -129,6 +139,11 @@ sub GetCountryCodeByName_geoip2 {
 		if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByName_geoip2 for $param: [$res]",5); }
 	}
 	elsif ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByName_geoip2 for $param: Already resolved to [$res]",5); }
+		1;
+	} or do {
+		$res='unknown';
+	};
+	# APM fin
 	# ----->
 	return $res;
 }
@@ -179,34 +194,56 @@ sub ShowInfoHost_geoip2 {
 		print "<td>";
 		if ($key && $ip==4) {
         	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param key=$key ip=$ip",5); }
-			my $res = TmpLookup_geoip2($param);
+			# APM debut ligne d'origine apres eval { et avant 1;
+			my $res="";
+			eval {
+			#$res = TmpLookup_geoip2($param);
         	if (!$res){$res=lc($reader->country( ip => $param )->country()->iso_code()) if $reader;}
+				1;
+			} or do {
+				$res="";
+			};
+			# APM fin
         	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param: [$res]",5); }
 		    if ($res) { print $DomainsHashIDLib{$res}?$DomainsHashIDLib{$res}:"<span style=\"color: #$color_other\">$Message[0]</span>"; }
 		    else { print "<span style=\"color: #$color_other\">$Message[0]</span>"; }
 		}
 		if ($key && $ip==6) {                              # GeoIP2 supports both IPv4 and IPv6
         	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param key=$key ip=$ip",5); }
-			my $res = TmpLookup_geoip2($param);
+			# APM debut ligne d'origine apres eval { et avant 1;
+			my $res="";
+			eval {
+			#$res = TmpLookup_geoip2($param);
         	if (!$res){$res=lc($reader->country( ip => $param )->country()->iso_code()) if $reader;}
+				1;
+			} or do {
+				$res="";
+			};
+			# APM fin
         	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param: [$res]",5); }
 		    if ($res) { print $DomainsHashIDLib{$res}?$DomainsHashIDLib{$res}:"<span style=\"color: #$color_other\">$Message[0]</span>"; }
 		    else { print "<span style=\"color: #$color_other\">$Message[0]</span>"; }
 		}
 		if (! $key) {
         	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param key=$key ip=$ip",5); }
-			my $res = TmpLookup_geoip2($param);
+			# APM debut ligne d'origine apres eval { et avant 1;
+			my $res="";
+			eval {
+			$res = TmpLookup_geoip2($param);
             # First resolve the name to an IP
             $address = inet_ntoa(inet_aton($param));
             if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 $param resolved to $address",5); }
             # Now do the same lookup from the IP
-            # GeoIP2::Reader doesn't support private IP addresses
-            if (!is_private_ip($address)){
         	if (!$res){$res=lc($reader->country( ip => $address )->country()->iso_code()) if $reader;}
+				1;
+			} or do {
+				$res="";
+			};
+			# APM fin
         	if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 for $param: [$res]",5); }
 		    if ($res) { print $DomainsHashIDLib{$res}?$DomainsHashIDLib{$res}:"<span style=\"color: #$color_other\">$Message[0]</span>"; }
 		    else { print "<span style=\"color: #$color_other\">$Message[0]</span>"; }
-		}}
+		}
 		print "</td>";
 	}
 	else {

--- a/wwwroot/cgi-bin/plugins/geoip2.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2.pm
@@ -98,14 +98,14 @@ sub GetCountryCodeByAddr_geoip2 {
 	# APM debut ligne d'origine apres eval { et avant 1; , le my devant $res doit etre hors bloc
 	my $res='unknown';
 	eval {
-	#$res= TmpLookup_geoip2($param);
-	#if (! $res) {
-		if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param",5); }
-		$res=lc($reader->country( ip => $param )->country()->iso_code()) || 'unknown';
-		$TmpDomainLookup{$param}=$res;
-		if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param: [$res]",5); }
-	#}
-	#elsif ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param: Already resolved to [$res]",5); }
+		$res= TmpLookup_geoip2($param);
+		if (! $res) {
+			if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param",5); }
+			$res=lc($reader->country( ip => $param )->country()->iso_code()) || 'unknown';
+			$TmpDomainLookup{$param}=$res;
+			if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param: [$res]",5); }
+		}
+		elsif ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByAddr_geoip2 for $param: Already resolved to [$res]",5); }
 		1;
 	} or do {
 		$res='unknown';
@@ -128,17 +128,17 @@ sub GetCountryCodeByName_geoip2 {
 	# APM debut ligne d'origine apres eval { et avant 1;
 	my $res='unknown';
 	eval {
-	$res = TmpLookup_geoip($param);
-	if (! $res) {
-        # First resolve the name to an IP
-        $address = inet_ntoa(inet_aton($param));
-		if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByName_geoip2 $param resolved to $address",5); }
-        # Now do the same lookup from the IP
-		$res=lc($reader->country( ip => $address )->country()->iso_code()) || 'unknown';
-		$TmpDomainLookup{$param}=$res;
-		if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByName_geoip2 for $param: [$res]",5); }
-	}
-	elsif ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByName_geoip2 for $param: Already resolved to [$res]",5); }
+		$res = TmpLookup_geoip($param);
+		if (! $res) {
+			# First resolve the name to an IP
+			$address = inet_ntoa(inet_aton($param));
+			if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByName_geoip2 $param resolved to $address",5); }
+			# Now do the same lookup from the IP
+			$res=lc($reader->country( ip => $address )->country()->iso_code()) || 'unknown';
+			$TmpDomainLookup{$param}=$res;
+			if ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByName_geoip2 for $param: [$res]",5); }
+		}
+		elsif ($Debug) { debug("  Plugin $PluginName: GetCountryCodeByName_geoip2 for $param: Already resolved to [$res]",5); }
 		1;
 	} or do {
 		$res='unknown';
@@ -197,8 +197,8 @@ sub ShowInfoHost_geoip2 {
 			# APM debut ligne d'origine apres eval { et avant 1;
 			my $res="";
 			eval {
-			#$res = TmpLookup_geoip2($param);
-        	if (!$res){$res=lc($reader->country( ip => $param )->country()->iso_code()) if $reader;}
+				$res = TmpLookup_geoip2($param);
+				if (!$res){$res=lc($reader->country( ip => $param )->country()->iso_code()) if $reader;}
 				1;
 			} or do {
 				$res="";
@@ -213,8 +213,8 @@ sub ShowInfoHost_geoip2 {
 			# APM debut ligne d'origine apres eval { et avant 1;
 			my $res="";
 			eval {
-			#$res = TmpLookup_geoip2($param);
-        	if (!$res){$res=lc($reader->country( ip => $param )->country()->iso_code()) if $reader;}
+				$res = TmpLookup_geoip2($param);
+				if (!$res){$res=lc($reader->country( ip => $param )->country()->iso_code()) if $reader;}
 				1;
 			} or do {
 				$res="";
@@ -229,12 +229,12 @@ sub ShowInfoHost_geoip2 {
 			# APM debut ligne d'origine apres eval { et avant 1;
 			my $res="";
 			eval {
-			$res = TmpLookup_geoip2($param);
-            # First resolve the name to an IP
-            $address = inet_ntoa(inet_aton($param));
-            if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 $param resolved to $address",5); }
-            # Now do the same lookup from the IP
-        	if (!$res){$res=lc($reader->country( ip => $address )->country()->iso_code()) if $reader;}
+				$res = TmpLookup_geoip2($param);
+				# First resolve the name to an IP
+				$address = inet_ntoa(inet_aton($param));
+				if ($Debug) { debug("  Plugin $PluginName: ShowInfoHost_geoip2 $param resolved to $address",5); }
+				# Now do the same lookup from the IP
+				if (!$res){$res=lc($reader->country( ip => $address )->country()->iso_code()) if $reader;}
 				1;
 			} or do {
 				$res="";


### PR DESCRIPTION
Capture les erreurs et donne 'unknown' sur une erreur. Ne bloque plus le calcul awstats lors de rencontre d'adresse IP non reconnue par la base.
Les concepteurs du paquet geoip2 ne corrigerons pas : https://github.com/maxmind/GeoIP2-perl/issues/54