### PR TITLE
Fix geoip2 formatting problem

### DIFF
--- a/wwwroot/cgi-bin/plugins/geoip2.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2.pm
@@ -142,6 +142,7 @@ sub ShowInfoHost_geoip2 {
         print "</th>";
 	}
 	elsif ($param) {
+		print "<td>";
 		my $res = Lookup_geoip2($param);
 		if ($res) {
 				$res = lc($res);


### PR DESCRIPTION
Missing <td> tag preceding GeoIP2 Country cell which causes all the _hosts_ related forms to be messed-up and very incorrect.