### PR TITLE
corner case 99

### DIFF
--- a/wwwroot/cgi-bin/plugins/graphgooglechartapi.pm
+++ b/wwwroot/cgi-bin/plugins/graphgooglechartapi.pm
@@ -582,7 +582,7 @@ sub Round_Up(){
 	$i = int(substr($num,0,2))+1;
 	
 	# pad with 0s
-	$l = length($i);
+	$l = 2;
 	while ($l<(length($num))){
 		$i .= "0";
 		$l++;


### PR DESCRIPTION
In case if the $num was 99711111, program would round it to 100 for the first two digits which is ok, but then it will eat one digit, in this case 7, so we would be a lower number, approx. 10 times lower, So $l should be 2, to indicate next character which was not considered in rounding. 