### PR TITLE
Fix geoip2 plugin on windows by renaming it

### DIFF
--- a/wwwroot/cgi-bin/awstats.model.conf
+++ b/wwwroot/cgi-bin/awstats.model.conf
@@ -1469,7 +1469,7 @@ color_x="C1B2E2"				# Background color for number of exit pages (Default = "C1B2
 # the now expired Legacy schema.
 # Replace spaces in the path of geoip data file with string "%20".
 #
-#LoadPlugin="geoip2 /pathto/GeoLite2-Country.mmdb"
+#LoadPlugin="geoip2_country /pathto/GeoLite2-Country.mmdb"
 
 # PLUGIN: GeoIP6
 # REQUIRED MODULES: Geo::IP or Geo::IP::PurePerl (from Maxmind, version >= 1.40)

--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -3314,7 +3314,7 @@ sub Read_Plugins {
 	if (   $PluginsLoaded{'init'}{'geoip'}
 		|| $PluginsLoaded{'init'}{'geoip6'}
 		|| $PluginsLoaded{'init'}{'geoipfree'}
-		|| $PluginsLoaded{'init'}{'geoip2'})
+		|| $PluginsLoaded{'init'}{'geoip2_country'})
 	{
 		$Message[17] = $Message[25] = $Message[148];
 	}
@@ -19435,8 +19435,8 @@ if ( $UpdateStats && $FrameName ne 'index' && $FrameName ne 'mainleft' )
 				elsif ( $PluginsLoaded{'GetCountryCodeByAddr'}{'geoipfree'} ) {
 					$Domain = GetCountryCodeByAddr_geoipfree($HostResolved);
 				}
-				elsif ( $PluginsLoaded{'GetCountryCodeByAddr'}{'geoip2'} ) {
-					$Domain = GetCountryCodeByAddr_geoip2($HostResolved);
+				elsif ( $PluginsLoaded{'GetCountryCodeByAddr'}{'geoip2_country'} ) {
+					$Domain = GetCountryCodeByAddr_geoip2_country($HostResolved);
 				}
 				if ($AtLeastOneSectionPlugin) {
 					foreach my $pluginname (
@@ -19473,9 +19473,9 @@ if ( $UpdateStats && $FrameName ne 'index' && $FrameName ne 'mainleft' )
 						$Domain = GetCountryCodeByAddr_geoipfree($Host);
 					}
 					elsif (
-						$PluginsLoaded{'GetCountryCodeByAddr'}{'geoip2'} )
+						$PluginsLoaded{'GetCountryCodeByAddr'}{'geoip2_country'} )
 					{
-						$Domain = GetCountryCodeByAddr_geoip2($Host);
+						$Domain = GetCountryCodeByAddr_geoip2_country($Host);
 					}
 					elsif ( $HostResolved =~ /\.(\w+)$/ ) { $Domain = $1; }
 					if ($AtLeastOneSectionPlugin) {
@@ -19507,9 +19507,9 @@ if ( $UpdateStats && $FrameName ne 'index' && $FrameName ne 'mainleft' )
 						$Domain = GetCountryCodeByName_geoipfree($HostResolved);
 					}
 					elsif (
-						$PluginsLoaded{'GetCountryCodeByName'}{'geoip2'} )
+						$PluginsLoaded{'GetCountryCodeByName'}{'geoip2_country'} )
 					{
-						$Domain = GetCountryCodeByName_geoip2($HostResolved);
+						$Domain = GetCountryCodeByName_geoip2_country($HostResolved);
 					}
 					elsif ( $HostResolved =~ /\.(\w+)$/ ) { $Domain = $1; }
 					if ($AtLeastOneSectionPlugin) {

--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -3135,7 +3135,7 @@ sub Read_Plugins {
 					'geoipfree'            => 'u',
 					'geoip'                => 'ou',
 					'geoip6'               => 'ou',
-					'geoip2'               => 'ou',
+					'geoip2_country'       => 'ou',
 					'geoip_region_maxmind' => 'mou',
 					'geoip_city_maxmind'   => 'mou',
                     'geoip2_city'          => 'mou',

--- a/wwwroot/cgi-bin/plugins/geoip2_country.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2_country.pm
@@ -142,6 +142,7 @@ sub ShowInfoHost_geoip2_country {
         print "</th>";
 	}
 	elsif ($param) {
+        print "<td>";
 		my $res = Lookup_geoip2_country($param);
 		if ($res) {
 				$res = lc($res);

--- a/wwwroot/cgi-bin/plugins/geoip2_country.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2_country.pm
@@ -13,7 +13,7 @@
 # <-----
 # ENTER HERE THE USE COMMAND FOR ALL REQUIRED PERL MODULES
 use vars qw/ $type /;
-$type='geoip2';
+$type='geoip2_country';
 if (!eval ('require "GeoIP2/Database/Reader.pm";')) {
 	$error=$@;
     $ret=($error)?"Error:\n$error":"";
@@ -41,7 +41,7 @@ no strict "refs";
 # AND THE NAME OF ALL FUNCTIONS THE PLUGIN MANAGE.
 my $PluginNeedAWStatsVersion="5.4";
 my $PluginHooksFunctions="GetCountryCodeByAddr GetCountryCodeByName ShowInfoHost";
-my $PluginName = "geoip2";
+my $PluginName = "geoip2_country";
 my $LoadedOverride=0;
 my $OverrideFile="";
 my %TmpDomainLookup;
@@ -59,7 +59,7 @@ use Data::Validate::IP 0.25 qw( is_public_ip );
 #-----------------------------------------------------------------------------
 # PLUGIN FUNCTION: Init_pluginname
 #-----------------------------------------------------------------------------
-sub Init_geoip2 {
+sub Init_geoip2_country {
 	my $InitParams=shift;
 	my $checkversion=&Check_Plugin_Version($PluginNeedAWStatsVersion);
 
@@ -92,10 +92,10 @@ sub Init_geoip2 {
 # UNIQUE: YES (Only one plugin using this function can be loaded)
 # GetCountryCodeByAddr is called to translate an ip into a country code in lower case.
 #-----------------------------------------------------------------------------
-sub GetCountryCodeByAddr_geoip2 {
+sub GetCountryCodeByAddr_geoip2_country {
 	my $param = shift;
 	if (! $param) { return ''; }
-	my $res = Lookup_geoip2($param);
+	my $res = Lookup_geoip2_country($param);
 	return ($res) ? lc($res) : 'unknown';
 }
 
@@ -105,8 +105,8 @@ sub GetCountryCodeByAddr_geoip2 {
 # UNIQUE: YES (Only one plugin using this function can be loaded)
 # GetCountryCodeByName is called to translate a host name into a country code in lower case.
 #-----------------------------------------------------------------------------
-sub GetCountryCodeByName_geoip2 {
-	return GetCountryCodeByAddr_geoip2(@_);
+sub GetCountryCodeByName_geoip2_country {
+	return GetCountryCodeByAddr_geoip2_country(@_);
 }
 
 
@@ -119,7 +119,7 @@ sub GetCountryCodeByName_geoip2 {
 #   print "<TD>This is a new cell for $param</TD>";
 # Parameters: Host name or ip
 #-----------------------------------------------------------------------------
-sub ShowInfoHost_geoip2 {
+sub ShowInfoHost_geoip2_country {
     my $param="$_[0]";
 	# <-----
 	if ($param eq '__title__') {
@@ -142,7 +142,7 @@ sub ShowInfoHost_geoip2 {
         print "</th>";
 	}
 	elsif ($param) {
-		my $res = Lookup_geoip2($param);
+		my $res = Lookup_geoip2_country($param);
 		if ($res) {
 				$res = lc($res);
 				print $DomainsHashIDLib{$res}?$DomainsHashIDLib{$res}:"<span style=\"color: #$color_other\">$Message[0]</span>";
@@ -163,7 +163,7 @@ sub ShowInfoHost_geoip2 {
 # Useful for Intranet records
 # CSV format: IP,2-char Country code
 #-----------------------------------------------------------------------------
-sub LoadOverrideFile_geoip2{
+sub LoadOverrideFile_geoip2_country{
 	my $filetoload="";
 	if ($OverrideFile){
 		if (!open(GEOIPFILE, $OverrideFile)){
@@ -202,10 +202,10 @@ sub LoadOverrideFile_geoip2{
 # associated country code; or undefined if not available.
 # GEOIP entry
 #-----------------------------------------------------------------------------
-sub Lookup_geoip2 {
+sub Lookup_geoip2_country {
 	$param = shift;
-	if (!$LoadedOverride) { &LoadOverrideFile_geoip2(); }
-	if ($Debug) { debug("  Plugin $PluginName: Lookup_geoip2 for $param",5); }
+	if (!$LoadedOverride) { &LoadOverrideFile_geoip2_country(); }
+	if ($Debug) { debug("  Plugin $PluginName: Lookup_geoip2_country for $param",5); }
 	if ($reader && !exists($TmpDomainLookup{$param})) {
 		$TmpDomainLookup{$param} = undef; # negative entry to avoid repeated lookups
 		# Resolve the parameter (either a name or an ip address) to a list of network addresses
@@ -215,7 +215,7 @@ sub Lookup_geoip2 {
 			my ($err, $address, $servicename) = Socket::getnameinfo($_->{addr}, Socket::NI_NUMERICHOST, Socket::NIx_NOSERV);
 			next if ($err || !is_public_ip($address));
 
-			if ($Debug && $param ne $address) { debug("  Plugin $PluginName: Lookup_geoip2 $param resolved to $address",5); }
+			if ($Debug && $param ne $address) { debug("  Plugin $PluginName: Lookup_geoip2_country $param resolved to $address",5); }
 			eval {
 				my $record = $reader->country(ip => $address);
 				$TmpDomainLookup{$param} = $record->country()->iso_code();
@@ -224,7 +224,7 @@ sub Lookup_geoip2 {
 		}
 	}
 	my $res = $TmpDomainLookup{$param};
-	if ($Debug) { debug("  Plugin $PluginName: Lookup_geoip2 for $param: [$res]",5); }
+	if ($Debug) { debug("  Plugin $PluginName: Lookup_geoip2_country for $param: [$res]",5); }
 	return $res;
 }
 


### PR DESCRIPTION
geoip2.pm as the plugin name clashes with GeoIP2.pm module in windows due to case insensitive file names. Renaming the plugin to geoip_country.pm and making the related changes in awstats.pl and in the plugin itself makes it work properly.

This was in part based on the observation made [here](https://sourceforge.net/p/awstats/discussion/43428/thread/e97df8e202/) and in part based my own experimentation. 


Closes #151 