### PR TITLE
Adding missing td-tag opening

### DIFF
--- a/wwwroot/cgi-bin/plugins/geoip2_country.pm
+++ b/wwwroot/cgi-bin/plugins/geoip2_country.pm
@@ -142,6 +142,7 @@ sub ShowInfoHost_geoip2_country {
         print "</th>";
 	}
 	elsif ($param) {
+		print "<td>";
 		my $res = Lookup_geoip2_country($param);
 		if ($res) {
 				$res = lc($res);


### PR DESCRIPTION
Adding td-tag before the country name, solving the problem with malformed table when using the geoip2_country plugin.