### PR TITLE
Unwrap SRS e-mail addresses

### DIFF
--- a/tools/maillogconvert.pl
+++ b/tools/maillogconvert.pl
@@ -76,9 +76,15 @@ sub CleanVadminUser { $_=shift||'';
 	return $_;
 }
 
+sub UnwrapSRS { $_=shift||'';
+	s/^SRS1=.*=([^=]+)=([^@]+)@.*$/\2@\1/g;
+	s/^SRS0=[^=]+=[^=]+=([^=]+)=([^@]+)@.*$/\2@\1/g;
+	return $_;
+}
+
 sub CleanEmail { $_=shift||'';
 	s/[#<|>\[\]]//g;	# Remove unwanted characters first
-	return $_;
+	return &UnwrapSRS($_);
 }
 
 # Clean host addresses


### PR DESCRIPTION
When building statistics from mail servers, messages which where processed by [Sender Rewriting Scheme](https://en.wikipedia.org/wiki/Sender_Rewriting_Scheme) (SRS) are mis-classified as internal mail while they are external, and appear to come from a huge number of different addresses which in fact correspond to the same actual sender.

Add a rewriting function that process such addresses and extract the relevant information from it.

With this change, the addresses `SRS0=HHH=TT=example.org=alice@example.com` and `SRS1=HHH=example.com==HHH=TT=example.org=alice@example.net` are converted to `alice@example.org`, the actual sender.