### PR TITLE
Fix #213:

### DIFF
--- a/wwwroot/cgi-bin/awstats.pl
+++ b/wwwroot/cgi-bin/awstats.pl
@@ -1313,7 +1313,7 @@ sub warning {
 		if ( !$HeaderHTTPSent && $ENV{'GATEWAY_INTERFACE'} ) { http_head(); }
 		if ( !$HeaderHTMLSent )        { html_head(); }
 		if ( scalar keys %HTMLOutput ) {
-			$messagestring =~ s/\n/\<br\>/g;
+			$messagestring =~ s,\n,<br />,g;
 			print "$messagestring<br />\n";
 		}
 		else {


### PR DESCRIPTION
Change the substitution that replaces newlines with BR elements so that the syntax works for both HTML and XHTML.