### PR TITLE
Remove native Android and native iOS/OSX Browser's User Agents from robots.pm

### DIFF
--- a/robots.pm
+++ b/robots.pm
@@ -43,6 +43,10 @@
 #
 #-------------------------------------------------------
 
+# 2023-07-04 RobC 
+#              Removed Dalvik as native Android UI Browser User Agent
+#              Removed CFNetwork as native iOS and OSX Browser User Agent
+
 # 2021-05--05 RobC
 
 # Removed Baidu catchall because its picking up baidu.sogo.uc.UCBrowser which is a phone browser
@@ -514,7 +518,6 @@
 'CUBOT',
 'Curl/PHP',
 'cyencebot',
-'Dalvik/',
 'DataCrawler/',
 'daumoa',
 'daum',
@@ -779,7 +782,6 @@
 'ng/1\.',
 'ng/2\.',
 'libwww\-perl',
-'CFNetwork',
 'urllib',
 'javabee',
 'projectwf\-java\-test\-crawler',
@@ -1696,7 +1698,6 @@
 'CUBOT','CUBOT',
 'Curl/PHP','Curl/PHP',
 'cyencebot','cyencebot',
-'Dalvik/','Dalvik',
 'DataCrawler/','DataCrawler',
 'daumoa','daumoa',
 'daum','daum',
@@ -1960,7 +1961,6 @@
 'ng/1\.','ng/1.',
 'ng/2\.','ng/2.',
 'libwww\-perl','libwww-perl',
-'CFNetwork','CFNetwork',
 'urllib','urllib',
 'javabee','javabee',
 'projectwf\-java\-test\-crawler','projectwf-java-test-crawler',

--- a/wwwroot/cgi-bin/lib/robots.pm
+++ b/wwwroot/cgi-bin/lib/robots.pm
@@ -43,6 +43,10 @@
 #
 #-------------------------------------------------------
 
+# 2023-07-04 RobC 
+#              Removed Dalvik as native Android UI Browser User Agent
+#              Removed CFNetwork as native iOS and OSX Browser User Agent
+
 # 2021-05--05 RobC
 
 # Removed Baidu catchall because its picking up baidu.sogo.uc.UCBrowser which is a phone browser
@@ -514,7 +518,6 @@
 'CUBOT',
 'Curl/PHP',
 'cyencebot',
-'Dalvik/',
 'DataCrawler/',
 'daumoa',
 'daum',
@@ -780,7 +783,6 @@
 'ng/1\.',
 'ng/2\.',
 'libwww\-perl',
-'CFNetwork',
 'urllib',
 'javabee',
 'projectwf\-java\-test\-crawler',
@@ -1696,7 +1698,6 @@
 'CUBOT','CUBOT',
 'Curl/PHP','Curl/PHP',
 'cyencebot','cyencebot',
-'Dalvik/','Dalvik',
 'DataCrawler/','DataCrawler',
 'daumoa','daumoa',
 'daum','daum',
@@ -1962,7 +1963,6 @@
 'ng/1\.','ng/1.',
 'ng/2\.','ng/2.',
 'libwww\-perl','libwww-perl',
-'CFNetwork','CFNetwork',
 'urllib','urllib',
 'javabee','javabee',
 'projectwf\-java\-test\-crawler','projectwf-java-test-crawler',


### PR DESCRIPTION
* native Android apps will request with User Agent  "**Dalvik**" 
* native iOS or OSX apps will request with User Agent "**CFNetwork**" 

These should not be considered as Robots, so this pull request removes them.

https://user-agents.net/applications/dalvik
