### PR TITLE
Correct IPv6 host name for EL8 and EL9

### DIFF
--- a/wwwroot/cgi-bin/plugins/ipv6.pm
+++ b/wwwroot/cgi-bin/plugins/ipv6.pm
@@ -63,8 +63,12 @@ sub GetResolvedIP_ipv6 {
 	my $query = $resolver->query($reverseip, "PTR");
 	if (! defined($query)) { return; }
 	my @result=split(/\s/, ($query->answer)[0]->string);
-	chop($result[4]); # Remove the trailing dot of the answer.
-	return $result[4];
+	my $hostindex = 6;
+	# Host name appears at index 6 on EL8 and EL9.
+	# On older operating systems, it appears at index 4 at the array's end.
+	if ($hostindex > $#result) { $hostindex = $#result; }
+	chop($result[$hostindex]); # Remove the trailing dot of the answer.
+	return $result[$hostindex];
 	# ----->
 }
 


### PR DESCRIPTION
On version 8 and 9 Linux operating systems (like Alma 8 and Alma 9 or more generally, EL8 and EL9), when AWStats reports an IPv6 host, it shows only the IPv6 address and not the host name. On an EL7 system like CentOS 7, the host name for an IPv6 host is shown correctly, just like for an IPv4 host. This problem was observed in the Worldwide Large Hadron Collider Computing Grid (WLCG) Squid monitoring system.

The problem occurs because `Net::DNS::Resolver->query()`returns a result aaray in a slightly different format on the two OS versions. On EL7, the host name is found at index 4 of the result array, while in EL8/EL9 it appears at index 6. 
This pull request updates the plugin `ipv6.pm` to correct this problem. This fix was tested on CentOS 7, Alma 8, and Alma 9.